### PR TITLE
WIP - Fix warning on bad api.idl

### DIFF
--- a/stackhut_toolkit/commands.py
+++ b/stackhut_toolkit/commands.py
@@ -373,8 +373,18 @@ class RunHostCmd(HutCmd, UserCmd):
             log.error('Exception while running service: %s', str(err))
         finally:
             toolkit_stack.del_shim()
-            os.remove(rpc.REQ_FIFO)
-            os.remove(rpc.RESP_FIFO)
+
+            # TODO: remove nested try blocks
+            if os.path.exists(rpc.REQ_FIFO):
+                try:
+                    os.remove(rpc.REQ_FIFO)
+                except:
+                    pass
+            if os.path.exists(rpc.RESP_FIFO):
+                try:
+                    os.remove(rpc.RESP_FIFO)
+                except:
+                    pass
 
 
 class DeployCmd(HutCmd, UserCmd):

--- a/stackhut_toolkit/commands.py
+++ b/stackhut_toolkit/commands.py
@@ -29,6 +29,7 @@ from stackhut_common.runtime.backends import LocalBackend
 from stackhut_common.runtime.runner import ServiceRunner
 from stackhut_common.commands import BaseCmd, HutCmd
 from stackhut_common.config import HutfileCfg, UserCfg
+from stackhut_common.exceptions import ConfigError
 from . import __version__
 from .utils import *
 from .builder import Service, bases, stacks, is_stack_supported, get_docker, OS_TYPE
@@ -367,6 +368,9 @@ class RunHostCmd(HutCmd, UserCmd):
             with ServiceRunner(backend, self.hutcfg) as runner:
                 log.info("Running service '{}' on http://127.0.0.1:{}".format(backend.service_short_name, self.port))
                 runner.run()
+        # surface errors caused by service configuration
+        except ConfigError as err:
+            log.error('Exception while running service: %s', str(err))
         finally:
             toolkit_stack.del_shim()
             os.remove(rpc.REQ_FIFO)


### PR DESCRIPTION
TODO:
- [x] discuss if this is desired functionality
- [ ] merge, commit, and release stackhut-common (https://github.com/StackHut/stackhut-common/pull/3)
- [ ] bumb stackhut-common requirement

This PR addresses https://github.com/StackHut/stackhut-toolkit/issues/1 and requires https://github.com/StackHut/stackhut-common/pull/3.

This includes two changes -- one that checks if files exist before deleting them, then silently ignores exceptions upon deleting them (TODO: decide if this is how file cleanup should be handled), and a second that surfaces errors caused by idl configuration in a more helpful package. Together they change the output in issue 1 to this instead:

```
(venv)➜  demo git:(master) ✗ stackhut -v runhost
21:08:45 [INFO ] Starting StackHut Toolkit
21:08:45 [DEBUG] User analytics enabled
21:08:45 [DEBUG] Starting service USERNAME/demo:latest
21:08:45 [INFO ] Started StackHut Request Server - press Ctrl-C to quit
21:08:45 [DEBUG] Starting Service Runner
21:08:45 [ERROR] Exception while running service: InvalidFunctionError: function definition "Default.add" is missing a return type
```

The stackhut-common changes add a custom exception type that represents a configuration error to differentiate between invalid config and an actual runtime error in the library. This consumes `stackhut_common.exceptions.ConfigError`s, prints them nicely to the console, and does _not_ raise them again, resulting in a simple, useable output without the stacktrace, automatic remote logging, and request for users to file an issue (when it isn't an issue with the library in the first place).
